### PR TITLE
Add a cli using click, with tests

### DIFF
--- a/coverage.cfg
+++ b/coverage.cfg
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+        if __name__ == .__main__.:

--- a/nvta_homework/cli.py
+++ b/nvta_homework/cli.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+
+def lift_cli(mapping_file, query_file):
+    """Lift the transcript locations onto the genome.
+
+    Lifts the transcript locations from the query file onto the
+    genome, using the mappings from the mapping file and print the
+    results in Invitae Standard Homework Format(tm).
+    """
+    print('Mapping queries in {0} using mapping in {1}'.format(
+        query_file, mapping_file))

--- a/nvta_homework/main.py
+++ b/nvta_homework/main.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import click
+
+from nvta_homework.cli import lift_cli
+
+
+@click.group()
+def main():
+    """Invitae homework CLI."""
+    pass  # noqa: WPS420
+
+
+@main.command()
+@click.option('--mf',
+              required=True,
+              help='The filename of the transcript mapping file')
+@click.option('--qf', required=True, help='The filename of the query file')
+def lift(mf, qf):
+    """Lift transcript locations onto genome.
+
+    Lift the transcript locations in the query_file onto the
+    genome, using the transcript<->genome mappings defined in the
+    mapping_file.
+    """
+    lift_cli(mf, qf)
+
+
+if __name__ == '__main__':
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,7 +15,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 version = "0.8.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Atomic file writes."
 marker = "sys_platform == \"win32\""
 name = "atomicwrites"
@@ -24,7 +24,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
@@ -80,7 +80,7 @@ python-versions = "*"
 version = "3.0.4"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
@@ -99,7 +99,7 @@ version = "0.0.4"
 setuptools = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Cross-platform colored terminal text."
 name = "colorama"
 optional = false
@@ -531,7 +531,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
@@ -664,7 +664,7 @@ python-versions = "*"
 version = "0.8.4"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
@@ -718,7 +718,7 @@ sortedcontainers = "*"
 toml = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
@@ -749,7 +749,7 @@ version = "0.9.1"
 flake8-polyfill = ">=1.0.2,<2"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
@@ -765,7 +765,7 @@ version = ">=0.12"
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
 optional = false
@@ -808,7 +808,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "2.5.2"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
@@ -816,7 +816,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "2.4.6"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
@@ -839,6 +839,18 @@ version = ">=0.12"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "main"
+description = "Py.test plugin for Click"
+name = "pytest-click"
+optional = false
+python-versions = "*"
+version = "0.3"
+
+[package.dependencies]
+click = ">=6.0"
+pytest = ">=3.6.0"
 
 [[package]]
 category = "dev"
@@ -985,7 +997,7 @@ requests = "*"
 setuptools = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
@@ -1207,7 +1219,7 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Measures number of Terminal column cells of wide-character codes"
 name = "wcwidth"
 optional = false
@@ -1261,7 +1273,7 @@ python-versions = "*"
 version = "0.29.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -1277,7 +1289,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "5affeb91cd6a3d33b22abdece84dbff4564a13624e3a8004b6a12f5cdf8ceec7"
+content-hash = "f77b56b74218b7ba80eecd2b56415869c534050fa76a248aad895f0bb630cf7d"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1631,6 +1643,9 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.3.2-py3-none-any.whl", hash = "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"},
     {file = "pytest-5.3.2.tar.gz", hash = "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa"},
+]
+pytest-click = [
+    {file = "pytest_click-0.3-py2.py3-none-any.whl", hash = "sha256:302102d8c966cfebdb89d3f81ae4342ca4072b735e89c7c6eee7443ac0a687ee"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+click = "^7.0"
+pytest-click = "^0.3"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.750"
@@ -51,3 +53,6 @@ sphinx-autodoc-typehints = "<1.11"
 doc8 = "^0.8"
 m2r = "^0.2"
 tomlkit = "^0.5"
+
+[tool.poetry.scripts]
+hw = 'nvta_homework.main:main'

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,8 @@ i-control-code = False
 
 # Disable some pydocstyle checks:
 # Exclude some pydoctest checks globally:
-ignore = D100, D104, D106, D401, W504, X100, RST303, RST304, DAR103, DAR203
+ignore = D100, D104, D106, D401, W504, X100, RST303, RST304, DAR103, DAR203,
+       WPS318, T001, WPS319, WPS317, WPS110
 
 # Excluding some directories:
 exclude =
@@ -71,6 +72,7 @@ addopts =
   --cov-report=html
   --cov-branch
   --cov-fail-under=100
+  --cov-config=coverage.cfg
 
 
 [mypy]

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from nvta_homework.main import main
+
+
+def test_cli(cli_runner):
+    """Test simple invocation of lift subcommand."""
+    result = cli_runner.invoke(main, ['lift', '--mf', 'foo', '--qf', 'bar'])
+    assert result.exit_code == 0


### PR DESCRIPTION
- Add a "click" driven cli.
- Add tests for it via pytest_click.
- The wemake flake8 config fights with yapf.  I don't have an opinion
  about who's right, so I'm just ignoring them for now.