### PR TITLE
Fix output capturing problem in test_cli

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,5 @@
 # Things ToDo(tm)
 
-## Unfinished business
-
-- [ ] figure out issue w/ capturing standard output in
-  tests/test_cli/test_main.py, pytest and click seem to be fighting
-  over my use of sys.stdout and the csv writer.
-
 ## Extensions
 
 - [ ] raise specific exception subclasses

--- a/nvta_homework/cli.py
+++ b/nvta_homework/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import csv
-from sys import stdout
+import sys
 
 from nvta_homework.queries import Queries
 from nvta_homework.transcript_mappings import TranscriptMappings
@@ -18,7 +18,7 @@ def lift_cli(mapping_file, query_file):
     tm.read_tsv(mapping_file)
     queries = Queries()
     queries.read_tsv(query_file)
-    tsv_writer = csv.writer(stdout, delimiter='\t')
+    tsv_writer = csv.writer(sys.stdout, delimiter='\t')
     for query in queries.queries:
         genome_location = tm.lift(query.transcript_name, query.pos)
         tsv_writer.writerow([

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -13,10 +13,9 @@ def test_cli():
     runner = CliRunner()
     result = runner.invoke(main, ['lift', '--mf', mf, '--qf', qf])
     assert result.exit_code == 0
-    # TODO: result.output is **empty**, but should not be...
-    # with open('sample_data/exhaustive_result.tsv') as the_file:
-    #     expected = the_file.read()
-    #     assert result.output == expected
+    with open('sample_data/exhaustive_result.tsv') as the_file:
+        expected = the_file.read()
+        assert result.output == expected
 
 
 def test_cli_bad_cigar():


### PR DESCRIPTION
Didn't figure this out myself, ended up asking for help from the click
folks (https://github.com/pallets/click/issues/1457)

Turns out that using

```
from sys import stdout

    #...
    tsv_writer = csv.writer(stdout, delimiter='\t')
```

worked across purposes with the magic that the test harness and click
do behind the scene to capture output; my code ends up with the
original value.

The fix is to use

```python
import sys

    #...
    tsv_writer = csv.writer(sys.stdout, delimiter='\t')
```