### PR TITLE
Disable caching of virtual environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2
 
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}
+      # - name: Cache Poetry virtualenv
+      #   uses: actions/cache@v1
+      #   id: cache
+      #   with:
+      #     path: ~/.virtualenvs
+      #     key: poetry-${{ hashFiles('**/poetry.lock') }}
+      #     restore-keys: |
+      #       poetry-${{ hashFiles('**/poetry.lock') }}
 
       - name: Set Poetry config
         run: |
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Dependencies
         run: poetry install
-        if: steps.cache.outputs.cache-hit != 'true'
+        # if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run test suite
         run: poetry run make test


### PR DESCRIPTION
There is, suddenly, something unhappy with the cached virtual
environments.

```
Run poetry run make test
The virtual environment found in /home/runner/.virtualenvs/nvta-homework-83GkQLFU-py3.7 seems to be broken.
Recreating virtualenv nvta-homework-83GkQLFU-py3.7 in /home/runner/.virtualenvs/nvta-homework-83GkQLFU-py3.7
flake8 --config=setup.cfg .
bash: flake8: command not found
make: *** [lint] Error 127
Makefile:5: recipe for target 'lint' failed
```

Disable the for the moment.